### PR TITLE
&& [ "$?" -eq 0 ] && is useless if && is used

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ g++ out.cpp
 Or a one liner:
 
 ```shell script
-./bfuck example/cat.txt && [ "$?" -eq 0 ] && g++ out.cpp && ./a.out
+./bfuck example/cat.txt && g++ out.cpp && ./a.out
 ```
 ---
 Feel free to contribute by opening issues or creating PR's.


### PR DESCRIPTION
&& already checks if the exit code is zero.
see number 3 of https://www.tecmint.com/chaining-operators-in-linux-with-practical-examples/